### PR TITLE
Adds basic repo docs: README, BUILD, CONTRIBUTING.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,41 @@
+# Build from source
+
+## Prerequisites
+
+- Go ≥ 1.24.
+- Make.
+- Git.
+- [Buf](https://buf.build/docs/installation) (only needed for Protobuf regeneration).
+
+## Steps
+
+```shell
+git clone git@github.com:shinzonetwork/shinzohub.git
+cd shinzohub
+make build
+```
+
+The compiled binary goes into `./build/shinzohubd`.
+
+## Useful commands
+
+| Command | What it does |
+| --- | --- |
+| `make build` | Build `shinzohubd` into `./build`. |
+| `make build-linux-amd64` | Cross-compile for Linux amd64. |
+| `make build-linux-arm64` | Cross-compile for Linux arm64. |
+| `make install` | Build and copy the binary to `~/.local/bin`. |
+| `make install-gopath` | Build and copy the binary to `$(GOPATH)/bin`. |
+| `make sh-testnet` | Start a local single-node testnet with a fresh chain state. |
+| `make doctor` | Check whether the binary was built and is on `PATH`. |
+| `make verify-deps` | Run `go mod verify` and `go mod tidy`. |
+| `make clean` | Remove the `./build` directory. |
+| `make proto-all` | Format, lint, and regenerate Go code from `.proto` files. |
+| `make proto-deps` | Install the required `protoc` plugins. |
+
+## Environment overrides
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BUILD_DIR` | `./build` | Output directory for compiled binaries. |
+| `LEDGER_ENABLED` | `true` | Enable or disable Ledger hardware wallet support. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Before you start
+
+Open an issue to discuss your proposed change before submitting a PR. This avoids wasted effort if the change isn't a good fit. PRs without an attached issue will be closed.
+
+## Making changes
+
+The repository is structured as follows:
+
+| Directory | Purpose |
+| --- | --- |
+| `app/` | Cosmos SDK application wiring, EVM precompile registration, ante handlers. |
+| `app/precompiles/` | Custom EVM precompiles: `ViewRegistry` and `EntityRegistry`. |
+| `cmd/shinzohubd/` | Entry point for the chain daemon binary. |
+| `cmd/registrar/` | Entry point for the standalone registrar service. |
+| `pkg/` | Shared packages: SourceHub IBC/ICA client adapters, validators, and utilities. |
+| `proto/` | Protobuf definitions. Run `make proto-all` after making changes here. |
+| `sdk/` | Go SDK for interacting with ShinzoHub from external clients. |
+| `scripts/` | Shell scripts for building, running a local testnet, and IBC/ICA demos. |
+| `x/sourcehub/` | The custom Cosmos SDK module that handles ICA message dispatch. |
+| `acp/` | Access control policy YAML definitions and test cases. |
+| `adrs/` | Architecture Decision Records. Add a new ADR before making significant design changes. |
+| `tests/` | ACP integration tests. |
+
+## Submitting a PR
+
+- Keep PRs focused. One change per PR.
+- Describe what you changed and why in the PR description.
+- Make sure `make build` and `make verify-deps` pass before requesting review.
+- If your change touches Protobuf definitions, run `make proto-all` and commit the generated files.
+- Leave plenty of comments. Assume reviewers are unfamiliar with the specific change you're making.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Cosmos SDK hub chain for the Shinzo network with EVM compatibility and on-chain access control policy management.
 
-> ![TIP]
+> ![WARNING]
 > If you're looking to run an Indexer, Host, or deploy a View, you don't need this repo. See the [Shinzo documentation site](https://docs.shinzo.network) for the right starting point. This repo is for Shinzo core developers and integration testers working on the chain itself.
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -1,166 +1,41 @@
-# Shinzohub
+<!--
+  This README covers local setup, Docker, and deployment only.
+  Do not add: architecture explanations, API reference, configuration 
+  deep-dives, or troubleshooting guides. Those belong in the Shinzo 
+  documentation site. If you're tempted to add a section, link to the docs 
+  instead.
+-->
 
-Shinzohub is a Cosmos SDK–based blockchain project with EVM compatibility and custom modules. This repo provides everything you need to build, install, and run the chain locally.
+# ShinzoHub
 
----
+[![Docker](https://img.shields.io/github/actions/workflow/status/shinzonetwork/shinzohub/.github/workflows/docker.yml?label=docker)](https://github.com/shinzonetwork/shinzohub/actions)
+[![License](https://img.shields.io/github/license/shinzonetwork/shinzohub)](./LICENSE)
 
-## ⚡️ Requirements
+Cosmos SDK hub chain for the Shinzo network with EVM compatibility and on-chain access control policy management.
 
-Before you start, ensure you have the following installed:
+> ![TIP]
+> If you're looking to run an Indexer, Host, or deploy a View, you don't need this repo. See the [Shinzo documentation site](https://docs.shinzo.network) for the right starting point. This repo is for Shinzo core developers and integration testers working on the chain itself.
 
-- **Go** ≥ 1.24
-- **Make**  
-- **Git**  
-- **Protobuf compiler (`protoc`)**  
-- [Buf](https://buf.build/docs/installation) (for linting/formatting Protobuf)  
-- Optional: [asdf](https://asdf-vm.com/) (if you manage your Go version via asdf)  
+## Getting started
 
----
-
-## 🔨 Building
-
-By default, binaries are built into `./build`.
-
-### Build for your local system
-```bash
+```shell
+git clone git@github.com:shinzonetwork/shinzohub.git
+cd shinzohub
 make build
-```
-
-Result:
-```
-./build/shinzohubd
-```
-
-### Cross-compile for Linux
-```bash
-make build-linux-amd64
-make build-linux-arm64
-```
-
----
-
-## 🚀 Installing
-
-### To your local bin (`~/.local/bin`)
-```bash
-make install
-```
-
-Afterwards, confirm:
-```bash
-shinzohubd version
-```
-
-### To GOPATH/bin
-```bash
-make install-gopath
-```
-
----
-
-## 🧹 Cleaning
-
-Remove all build artifacts:
-```bash
-make clean
-```
-
----
-
-## 🛠 Verifying Dependencies
-
-To ensure Go modules are tidy and not corrupted:
-```bash
-make verify-deps
-```
-
----
-
-## 📦 Protobuf
-
-Protobuf files live under `./proto`.
-
-### Install Protobuf dependencies
-```bash
-make proto-deps
-```
-
-### Generate Protobuf code
-```bash
-make proto-gen
-```
-
-### Lint Protobuf definitions
-```bash
-make proto-lint
-```
-
-### Format Protobuf files
-```bash
-make proto-format
-```
-
-Or run all in one go:
-```bash
-make proto-all
-```
-
----
-
-## 🌐 Development
-
-### Doctor check
-Quick project health check:
-```bash
-make doctor
-```
-
-Output will confirm:
-- If the build artifact exists
-- If `shinzohubd` is on your PATH  
-
-
-### Start a local testnet
-```bash
 make sh-testnet
 ```
 
-This spins up a chain with:
+> [!TIP]
+> See [BUILD.md](./BUILD.md) for full build-from-source instructions.
 
-- `CHAIN_ID=91273002`  
-- `BLOCK_TIME=1000ms`  
-- Fresh state each run (`CLEAN=true`)  
+## Deployment
 
----
+See the [Shinzo documentation site](https://docs.shinzo.network) for production deployment instructions.
 
-## 📝 Notes
+## Contributing
 
-- You can override build settings via environment variables:  
-  - `BUILD_DIR` → change binary output directory  
-  - `LEDGER_ENABLED` → enable/disable Ledger support (default: `true`)  
+Open an issue before submitting a PR. See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
-Example:
-```bash
-BUILD_DIR=/tmp/shinzohub LEDGER_ENABLED=false make build
-```
+## License
 
----
-
-## ✅ Quickstart
-
-```bash
-# 1. Verify dependencies
-make verify-deps
-
-# 2. Build the binary
-make build
-
-# 3. Install it
-make install
-
-# 4. Check installation
-shinzohubd version
-
-# 5. Run a local testnet
-make sh-testnet
-```
+[MIT](./LICENSE)


### PR DESCRIPTION
Addresses https://github.com/shinzonetwork/meta/issues/7. Doesn't specifically close that issue though.

<!-- Issue number is required. PRs without a linked issue will be closed. -->

## Summary

Adds basic repo documentation, cleans up the README to contain only the info need immediately needs, and points out that most folk don't need to interact with this repo at all.

## Changes

- Updates README.md
- Adds BUILD.md and CONTRIBUTING.md

## Testing

Run the steps in README.md and BUILD.md, and make sure they actually work.

## Notes for reviewers

N/a
