### PR TITLE
build: add scripts for dockerized demo

### DIFF
--- a/scripts/demo/docker-compose.yaml
+++ b/scripts/demo/docker-compose.yaml
@@ -1,0 +1,30 @@
+name: shinzohub-demo
+
+services:
+  sourcehub:
+    image: ghcr.io/sourcenetwork/sourcehub:dev
+    environment:
+      STANDALONE: "1"
+      CHAIN_ID: "sourcehub"
+      MONIKER: "node"
+    ports:
+      - "27686:26657"
+      - "9095:9090"
+      - "1318:1317"
+    healthcheck:
+      test: ["CMD-SHELL", "sourcehubd status --node tcp://localhost:26657 >/dev/null 2>&1"]
+      interval: 2s
+      timeout: 2s
+      retries: 60
+
+  hermes:
+    image: informalsystems/hermes:1.13.1
+    depends_on:
+      sourcehub:
+        condition: service_healthy
+    volumes:
+      - ./hermes/config.toml:/tmp/hermes-config.toml:ro
+      - ./hermes/entrypoint.sh:/usr/local/bin/shinzo-hermes-entrypoint.sh:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    entrypoint: ["/bin/bash", "/usr/local/bin/shinzo-hermes-entrypoint.sh"]

--- a/scripts/demo/hermes/config.toml
+++ b/scripts/demo/hermes/config.toml
@@ -1,0 +1,56 @@
+[global]
+log_level = 'info'
+
+[mode]
+[mode.clients]
+enabled = true
+refresh = true
+misbehaviour = true
+[mode.connections]
+enabled = true
+[mode.channels]
+enabled = true
+[mode.packets]
+enabled = true
+clear_interval = 100
+clear_on_start = true
+
+[[chains]]
+id = 'sourcehub'
+type = 'CosmosSdk'
+rpc_addr = 'http://sourcehub:26657'
+grpc_addr = 'http://sourcehub:9090'
+event_source = { mode = 'push', url = 'ws://sourcehub:26657/websocket', batch_delay = '500ms' }
+rpc_timeout = '10s'
+trusted_node = false
+account_prefix = 'source'
+key_name = 'source'
+store_prefix = 'ibc'
+default_gas = 100000
+max_gas = 4000000
+gas_price = { price = 0.025, denom = 'uopen' }
+gas_multiplier = 1.2
+clock_drift = '10s'
+trusting_period = '14days'
+trust_threshold = '2/3'
+address_type = { derivation = 'cosmos' }
+
+[[chains]]
+id = '91273002'
+type = 'CosmosSdk'
+rpc_addr = 'http://host.docker.internal:26657'
+grpc_addr = 'http://host.docker.internal:9090'
+event_source = { mode = 'push', url = 'ws://host.docker.internal:26657/websocket', batch_delay = '500ms' }
+rpc_timeout = '10s'
+trusted_node = false
+account_prefix = 'shinzo'
+key_name = 'shinzo'
+store_prefix = 'ibc'
+default_gas = 100000
+max_gas = 4000000
+gas_price = { price = 0.00001, denom = 'ushinzo' }
+gas_multiplier = 1.2
+clock_drift = '10s'
+trusting_period = '14days'
+trust_threshold = '2/3'
+address_type = { derivation = 'ethermint', proto_type = { pk_type = '/cosmos.evm.crypto.v1.ethsecp256k1.PubKey' } }

--- a/scripts/demo/hermes/entrypoint.sh
+++ b/scripts/demo/hermes/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=/home/hermes/.hermes/config.toml
+MNEMONIC="divert tenant reveal hire thing jar carry lonely magic oak audit fiber earth catalog cheap merry print clown portion speak daring giant weird slight"
+
+# Stage the config in a directory the `hermes` user owns.
+mkdir -p /home/hermes/.hermes
+cp /tmp/hermes-config.toml "$CONFIG"
+
+echo "==> Adding hermes keys..."
+echo "$MNEMONIC" > /tmp/mnemonic.txt
+hermes --config "$CONFIG" keys add --chain sourcehub --mnemonic-file /tmp/mnemonic.txt
+hermes --config "$CONFIG" keys add --chain 91273002 --mnemonic-file /tmp/mnemonic.txt --hd-path "m/44'/60'/0'/0/0"
+rm /tmp/mnemonic.txt
+
+echo "==> Creating IBC connection (retrying until both chains are ready)..."
+for i in $(seq 1 60); do
+  if hermes --config "$CONFIG" create connection \
+       --a-chain sourcehub --b-chain 91273002; then
+    echo "==> Connection created."
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "ERROR: hermes create connection failed after 60 attempts"
+    exit 1
+  fi
+  echo "    attempt $i failed, retrying in 2s..."
+  sleep 2
+done
+
+echo "==> Starting hermes..."
+exec hermes --config "$CONFIG" start

--- a/scripts/demo/start_all_docker.sh
+++ b/scripts/demo/start_all_docker.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────
+# Master script: start everything for ShinzoHub + SourceHub demo
+# using Docker for SourceHub and Hermes.
+#
+# This script:
+#   1. Builds ShinzoHub
+#   2. Starts SourceHub in a container (ghcr.io image)
+#   3. Starts ShinzoHub on the host (fresh state each run)
+#   4. Starts Hermes in a container, which creates the IBC connection
+#   5. Registers ICA + Shinzo policy from the host
+#
+# Usage:
+#   sh scripts/demo/start_all_docker.sh
+#
+# To stop everything:
+#   sh scripts/demo/stop_all_docker.sh
+# ──────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ICA_DIR="$SCRIPT_DIR/../ica"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yaml"
+cd "$PROJECT_DIR"
+
+LOG_DIR="$PROJECT_DIR/.logs"
+mkdir -p "$LOG_DIR"
+
+# ── Cleanup from previous runs ──
+echo "==> Stopping previous processes and containers..."
+killall shinzohubd 2>/dev/null || true
+docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+sleep 1
+
+# 1. Build ShinzoHub
+echo "==> Building ShinzoHub..."
+make build
+
+# 2. Start SourceHub container 
+echo "==> Starting SourceHub container..."
+docker compose -f "$COMPOSE_FILE" up -d sourcehub
+
+echo "==> Waiting for SourceHub to be healthy..."
+for i in $(seq 1 60); do
+  STATUS=$(docker compose -f "$COMPOSE_FILE" ps --format json sourcehub 2>/dev/null | grep -o '"Health":"[^"]*"' | cut -d'"' -f4 || true)
+  if [ "$STATUS" = "healthy" ]; then
+    echo "    SourceHub is healthy."
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "ERROR: SourceHub did not become healthy. Check: docker compose -f $COMPOSE_FILE logs sourcehub"
+    exit 1
+  fi
+  sleep 1
+done
+
+# 3. Fund hermes account on SourceHub
+# Hermes derives source1cy0p47z24ejzvq55pu3lesxwf73xnrnd0lyxme from the shared
+# mnemonic. The standalone sourcehub container funds only validator + faucet,
+# so we top up the hermes account from the faucet here.
+HERMES_SOURCEHUB_ADDR="source1cy0p47z24ejzvq55pu3lesxwf73xnrnd0lyxme"
+echo "==> Funding hermes account on SourceHub..."
+docker compose -f "$COMPOSE_FILE" exec -T sourcehub \
+  sourcehubd tx bank send faucet "$HERMES_SOURCEHUB_ADDR" 100000000uopen \
+    --keyring-backend test \
+    --chain-id sourcehub \
+    --fees 1000uopen \
+    --yes > /dev/null
+sleep 3
+
+# 4. Start ShinzoHub on host
+echo "==> Starting ShinzoHub on host..."
+sh "$ICA_DIR/start_shinzohub_node.sh" > "$LOG_DIR/shinzohub.log" 2>&1 &
+SHINZOHUB_PID=$!
+echo "    PID: $SHINZOHUB_PID (log: .logs/shinzohub.log)"
+
+echo "==> Waiting for ShinzoHub RPC (port 26657)..."
+for i in $(seq 1 60); do
+  if curl -s http://localhost:26657/status > /dev/null 2>&1; then
+    echo "    ShinzoHub is ready."
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "ERROR: ShinzoHub did not start within 60s. Check .logs/shinzohub.log"
+    exit 1
+  fi
+  sleep 1
+done
+
+# 5. Start Hermes container
+echo "==> Starting Hermes container..."
+docker compose -f "$COMPOSE_FILE" up -d hermes
+
+echo "==> Waiting for IBC connection to be established..."
+# Hermes creates the connection during its entrypoint; allow time.
+sleep 20
+
+# 5. Register ICA + Shinzo policy from host
+echo "==> Registering ICA..."
+sh "$ICA_DIR/register_ica.sh"
+
+echo "==> Waiting for ICA channel handshake to complete..."
+BINARY="${BINARY:-./build/shinzohubd}"
+for i in $(seq 1 60); do
+  STATE=$($BINARY q ibc channel channels --node tcp://127.0.0.1:26657 -o json 2>/dev/null \
+    | grep -o '"state":"STATE_OPEN"' | head -1 || true)
+  if [ -n "$STATE" ]; then
+    echo "    ICA channel is OPEN."
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "ERROR: ICA channel did not open within 120s. Check hermes logs."
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "==> Registering Shinzo policy..."
+sh "$ICA_DIR/register_shinzo_policy.sh"
+sleep 5
+
+echo "==> Registering Shinzo objects (group/host, group/indexer, primitives)..."
+sh "$ICA_DIR/register_shinzo_objects.sh"
+sleep 5
+
+echo ""
+echo "==> All services are running!"
+echo "    ShinzoHub:  tail -f .logs/shinzohub.log"
+echo "    SourceHub:  docker compose -f $COMPOSE_FILE logs -f sourcehub"
+echo "    Hermes:     docker compose -f $COMPOSE_FILE logs -f hermes"
+echo ""
+echo "    Stop:       sh scripts/demo/stop_all_docker.sh"

--- a/scripts/demo/stop_all_docker.sh
+++ b/scripts/demo/stop_all_docker.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Stop everything started by start_all_docker.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yaml"
+
+echo "==> Stopping ShinzoHub on host..."
+killall shinzohubd 2>/dev/null && echo "    Stopped shinzohubd" || echo "    shinzohubd not running"
+
+echo "==> Stopping SourceHub + Hermes containers..."
+docker compose -f "$COMPOSE_FILE" down -v
+
+echo "==> Done."


### PR DESCRIPTION
I found it very painful and slow to run the demo scirpts (especially getting hermes to work).

This PR adds dockerized version of the demo - sourcehub and hermes are started in containers (no need to fetch / build them!) and shinzohub is build and used as normal application. This way we can focus only on shinzohub development, not on the dependecies.