### PR TITLE
Menna/tx participant events

### DIFF
--- a/app/ante/ante_cosmos.go
+++ b/app/ante/ante_cosmos.go
@@ -10,6 +10,8 @@ import (
 
 	circuitante "cosmossdk.io/x/circuit/ante"
 	ibcante "github.com/cosmos/ibc-go/v10/modules/core/ante"
+
+	"github.com/shinzonetwork/shinzohub/app/decorators"
 )
 
 // newCosmosAnteHandler creates the default ante handler for Cosmos transactions
@@ -39,5 +41,9 @@ func NewCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
 		evmante.NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
+		// Last in the chain: emit participant index events only for txs that pass
+		// the ante checks (the set that lands in a block), into the finalized
+		// event manager that baseapp reads for ante events.
+		decorators.NewTxParticipantDecorator(),
 	)
 }

--- a/app/ante/ante_evm.go
+++ b/app/ante/ante_evm.go
@@ -3,6 +3,9 @@ package ante
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	evmante "github.com/cosmos/evm/ante/evm"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	"github.com/shinzonetwork/shinzohub/app/decorators"
 )
 
 // newMonoEVMAnteHandler creates the sdk.AnteHandler implementation for the EVM transactions.
@@ -14,5 +17,41 @@ func newMonoEVMAnteHandler(options HandlerOptions) sdk.AnteHandler {
 			options.EvmKeeper,
 			options.MaxTxGasWanted,
 		),
+		// After the mono decorator: it runs signature verification, which is what
+		// populates MsgEthereumTx.From, so the sender is available here.
+		evmParticipantDecorator{},
 	)
+}
+
+// evmParticipantDecorator emits the shinzo participant events for an EVM tx: the
+// recovered sender (From) and, when present, the recipient (To; nil for contract
+// creation). Both are the bech32 of the 20-byte EVM address, the form the bank
+// module already uses for an EVM account, so an account keeps one address key
+// across its EVM and Cosmos activity.
+type evmParticipantDecorator struct{}
+
+func (evmParticipantDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if simulate {
+		return next(ctx, tx, simulate)
+	}
+
+	var senders, recipients []string
+	for _, msg := range tx.GetMsgs() {
+		ethMsg, ok := msg.(*evmtypes.MsgEthereumTx)
+		if !ok {
+			continue
+		}
+		senders = append(senders, ethMsg.GetFrom().String())
+		// AsTransaction is non-nil here in practice (the mono decorator already
+		// unpacked and verified the inner tx), but guard it so a reordering of the
+		// chain can't turn this into an ante-path panic.
+		if ethTx := ethMsg.AsTransaction(); ethTx != nil {
+			if to := ethTx.To(); to != nil {
+				recipients = append(recipients, sdk.AccAddress(to.Bytes()).String())
+			}
+		}
+	}
+	decorators.EmitParticipants(ctx, senders, recipients)
+
+	return next(ctx, tx, simulate)
 }

--- a/app/decorators/tx_participant.go
+++ b/app/decorators/tx_participant.go
@@ -1,0 +1,154 @@
+package decorators
+
+import (
+	feegrant "cosmossdk.io/x/feegrant"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+)
+
+// Event type and attribute keys for the participant index. The KV indexer stores
+// the composite tag "<type>.<key>", so the query key is "shinzo.address". A single
+// equality condition matches any occurrence, so one event per participant lets
+// "shinzo.address='X'" match X as a sender or a recipient.
+const (
+	EventTypeTxParticipant = "shinzo"
+	AttributeKeyAddress    = "address"
+	AttributeKeyRole       = "role"
+	RoleSender             = "sender"
+	RoleRecipient          = "recipient"
+)
+
+// TxParticipantDecorator emits one indexed `shinzo` event per distinct
+// participant address in a Cosmos tx, so a single `shinzo.address='X'` tx_search
+// matches X as a sender or a recipient and pages natively.
+//
+// It emits from the ante path because ante events are indexed even when message
+// execution later fails, which keeps failed txs queryable by participant; it
+// skips simulation, which must stay side-effect free.
+//
+// The event is per participant because the KV indexer intersects ANDed conditions
+// within a single event (by event sequence): each address must carry its own role
+// for `shinzo.address='X' AND shinzo.role='sender'` to mean X was the sender.
+// Collapsing all participants into one event would break that.
+type TxParticipantDecorator struct{}
+
+// NewTxParticipantDecorator returns the participant-emitting ante decorator.
+func NewTxParticipantDecorator() TxParticipantDecorator {
+	return TxParticipantDecorator{}
+}
+
+func (TxParticipantDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if !simulate {
+		senders, recipients := CollectParticipants(tx)
+		EmitParticipants(ctx, senders, recipients)
+	}
+	return next(ctx, tx, simulate)
+}
+
+// CollectParticipants returns the distinct sender and recipient addresses of a
+// tx. Senders are the tx signers (universal across every message type) unioned
+// with the from-side of any value-transfer message, including authz-wrapped
+// ones. Recipients are the to-side of those messages. Returned slices are
+// deduplicated and in first-seen order.
+func CollectParticipants(tx sdk.Tx) (senders, recipients []string) {
+	s := newAddrSet()
+	r := newAddrSet()
+
+	// Universal senders: the tx signers, available for any message type via the
+	// cosmos.msg.v1.signer annotation. Recipients have no such uniform interface,
+	// so they are pulled per message type below.
+	if sigTx, ok := tx.(authsigning.SigVerifiableTx); ok {
+		if signers, err := sigTx.GetSigners(); err == nil {
+			for _, signer := range signers {
+				s.add(sdk.AccAddress(signer).String())
+			}
+		}
+	}
+
+	collectFromMsgs(tx.GetMsgs(), s, r)
+	return s.list(), r.list()
+}
+
+// collectFromMsgs records the from/to addresses of the value-transfer message
+// types. authz.MsgExec is unwrapped one level so inner participants are captured.
+// Types with no recipient (votes, signer-only custom messages) appear only
+// through their signer in CollectParticipants, so they are not listed here.
+func collectFromMsgs(msgs []sdk.Msg, senders, recipients *addrSet) {
+	for _, msg := range msgs {
+		switch m := msg.(type) {
+		case *banktypes.MsgSend:
+			senders.add(m.FromAddress)
+			recipients.add(m.ToAddress)
+		case *banktypes.MsgMultiSend:
+			for _, in := range m.Inputs {
+				senders.add(in.Address)
+			}
+			for _, out := range m.Outputs {
+				recipients.add(out.Address)
+			}
+		case *ibctransfertypes.MsgTransfer:
+			senders.add(m.Sender)
+			recipients.add(m.Receiver)
+		case *distrtypes.MsgSetWithdrawAddress:
+			recipients.add(m.WithdrawAddress)
+		case *authz.MsgGrant:
+			recipients.add(m.Grantee)
+		case *feegrant.MsgGrantAllowance:
+			recipients.add(m.Grantee)
+		case *authz.MsgExec:
+			if inner, err := m.GetMessages(); err == nil {
+				collectFromMsgs(inner, senders, recipients)
+			}
+		}
+	}
+}
+
+// EmitParticipants writes one `shinzo` event per (address, role). An address that
+// is both sender and recipient gets one event per role; tx_search dedups by hash,
+// so the role-agnostic query still returns the tx once. Exported for the EVM ante
+// path, which emits the same events.
+func EmitParticipants(ctx sdk.Context, senders, recipients []string) {
+	for _, addr := range senders {
+		emitParticipant(ctx, addr, RoleSender)
+	}
+	for _, addr := range recipients {
+		emitParticipant(ctx, addr, RoleRecipient)
+	}
+}
+
+func emitParticipant(ctx sdk.Context, address, role string) {
+	if address == "" {
+		return
+	}
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		EventTypeTxParticipant,
+		sdk.NewAttribute(AttributeKeyAddress, address),
+		sdk.NewAttribute(AttributeKeyRole, role),
+	))
+}
+
+// addrSet is an insertion-ordered string set, so emitted events are
+// deterministic for a given tx.
+type addrSet struct {
+	seen  map[string]struct{}
+	order []string
+}
+
+func newAddrSet() *addrSet { return &addrSet{seen: make(map[string]struct{})} }
+
+func (a *addrSet) add(addr string) {
+	if addr == "" {
+		return
+	}
+	if _, ok := a.seen[addr]; ok {
+		return
+	}
+	a.seen[addr] = struct{}{}
+	a.order = append(a.order, addr)
+}
+
+func (a *addrSet) list() []string { return a.order }

--- a/app/decorators/tx_participant_test.go
+++ b/app/decorators/tx_participant_test.go
@@ -1,0 +1,124 @@
+package decorators_test
+
+import (
+	"testing"
+
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	txsigning "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shinzonetwork/shinzohub/app/decorators"
+)
+
+// signerMockTx adds GetSigners to MockTx so the universal sender path
+// (authsigning.SigVerifiableTx) can be exercised without a full tx builder.
+type signerMockTx struct {
+	decorators.MockTx
+	signers [][]byte
+}
+
+func (tx signerMockTx) GetSigners() ([][]byte, error)                  { return tx.signers, nil }
+func (signerMockTx) GetPubKeys() ([]cryptotypes.PubKey, error)         { return nil, nil }
+func (signerMockTx) GetSignaturesV2() ([]txsigning.SignatureV2, error) { return nil, nil }
+
+func TestCollectParticipantsMsgSend(t *testing.T) {
+	msg := &banktypes.MsgSend{FromAddress: "shinzo1alice", ToAddress: "shinzo1bob"}
+
+	senders, recipients := decorators.CollectParticipants(decorators.NewMockTx(msg))
+
+	require.Equal(t, []string{"shinzo1alice"}, senders)
+	require.Equal(t, []string{"shinzo1bob"}, recipients)
+}
+
+func TestCollectParticipantsMultiSend(t *testing.T) {
+	msg := &banktypes.MsgMultiSend{
+		Inputs:  []banktypes.Input{{Address: "shinzo1alice"}},
+		Outputs: []banktypes.Output{{Address: "shinzo1bob"}, {Address: "shinzo1carol"}},
+	}
+
+	senders, recipients := decorators.CollectParticipants(decorators.NewMockTx(msg))
+
+	require.Equal(t, []string{"shinzo1alice"}, senders)
+	require.ElementsMatch(t, []string{"shinzo1bob", "shinzo1carol"}, recipients)
+}
+
+// A self-send still produces the address once per role; the role-agnostic query
+// dedups by tx hash at search time, so this is the intended shape.
+func TestCollectParticipantsSelfSend(t *testing.T) {
+	msg := &banktypes.MsgSend{FromAddress: "shinzo1alice", ToAddress: "shinzo1alice"}
+
+	senders, recipients := decorators.CollectParticipants(decorators.NewMockTx(msg))
+
+	require.Equal(t, []string{"shinzo1alice"}, senders)
+	require.Equal(t, []string{"shinzo1alice"}, recipients)
+}
+
+// A message with no recipient field (here a reward withdrawal, which is not in
+// the value-transfer switch) contributes its signer as the only participant.
+func TestCollectParticipantsSignerOnly(t *testing.T) {
+	signer := []byte("0123456789abcdef0123") // 20 bytes
+	tx := signerMockTx{
+		MockTx:  decorators.NewMockTx(&distrtypes.MsgWithdrawDelegatorReward{}),
+		signers: [][]byte{signer},
+	}
+
+	senders, recipients := decorators.CollectParticipants(tx)
+
+	require.Equal(t, []string{sdk.AccAddress(signer).String()}, senders)
+	require.Empty(t, recipients)
+}
+
+func TestAnteHandleEmitsParticipants(t *testing.T) {
+	ctx := sdk.Context{}.WithEventManager(sdk.NewEventManager())
+	msg := &banktypes.MsgSend{FromAddress: "shinzo1alice", ToAddress: "shinzo1bob"}
+
+	_, err := decorators.NewTxParticipantDecorator().
+		AnteHandle(ctx, decorators.NewMockTx(msg), false, decorators.EmptyAnte)
+	require.NoError(t, err)
+
+	require.Equal(t, []participant{
+		{address: "shinzo1alice", role: decorators.RoleSender},
+		{address: "shinzo1bob", role: decorators.RoleRecipient},
+	}, participantsFromEvents(t, ctx))
+}
+
+// Simulation must stay side-effect free; no participant events are emitted.
+func TestAnteHandleSkipsSimulate(t *testing.T) {
+	ctx := sdk.Context{}.WithEventManager(sdk.NewEventManager())
+	msg := &banktypes.MsgSend{FromAddress: "shinzo1alice", ToAddress: "shinzo1bob"}
+
+	_, err := decorators.NewTxParticipantDecorator().
+		AnteHandle(ctx, decorators.NewMockTx(msg), true, decorators.EmptyAnte)
+	require.NoError(t, err)
+
+	require.Empty(t, ctx.EventManager().Events())
+}
+
+type participant struct {
+	address string
+	role    string
+}
+
+func participantsFromEvents(t *testing.T, ctx sdk.Context) []participant {
+	t.Helper()
+	var out []participant
+	for _, event := range ctx.EventManager().Events() {
+		if event.Type != decorators.EventTypeTxParticipant {
+			continue
+		}
+		var p participant
+		for _, attr := range event.Attributes {
+			switch attr.Key {
+			case decorators.AttributeKeyAddress:
+				p.address = attr.Value
+			case decorators.AttributeKeyRole:
+				p.role = attr.Value
+			}
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.5 // indirect
 	github.com/cockroachdb/redact v1.1.6 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20250429170803-42689b6311bb // indirect
-	github.com/cometbft/cometbft-db v0.14.1 // indirect
+	github.com/cometbft/cometbft-db v0.14.1
 	github.com/consensys/gnark-crypto v0.18.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect

--- a/tests/txparticipant/participant_index_test.go
+++ b/tests/txparticipant/participant_index_test.go
@@ -1,0 +1,127 @@
+// Package txparticipant validates the participant-index design end to end against
+// the real CometBFT v0.38.19 KV transaction indexer. It indexes synthetic tx
+// results carrying the `shinzo` participant events the ante decorators emit, then
+// runs tx_search queries to confirm the query behavior the index must support:
+//
+//   - shinzo.address='X' matches a tx whether X was a sender or a recipient, and
+//     a self-transfer returns once (OR semantics + dedup).
+//   - shinzo.address='X' AND shinzo.role='sender' returns only txs where X was
+//     the sender, because address and role are bound within a single event.
+//   - the rejected tx-level schema (all addresses + all roles on one event)
+//     produces a false positive on the role query, which is why the decorators
+//     emit one event per participant instead.
+package txparticipant
+
+import (
+	"context"
+	"testing"
+
+	dbm "github.com/cometbft/cometbft-db"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/pubsub/query"
+	"github.com/cometbft/cometbft/state/txindex/kv"
+	"github.com/stretchr/testify/require"
+)
+
+func p(address, role string) [2]string { return [2]string{address, role} }
+
+// participantTx builds a tx result in the shape the ante decorators produce: one
+// `shinzo` event per participant, each carrying that participant's address and role.
+func participantTx(height int64, index uint32, tx string, participants ...[2]string) *abci.TxResult {
+	events := make([]abci.Event, 0, len(participants))
+	for _, participant := range participants {
+		events = append(events, abci.Event{
+			Type: "shinzo",
+			Attributes: []abci.EventAttribute{
+				{Key: "address", Value: participant[0], Index: true},
+				{Key: "role", Value: participant[1], Index: true},
+			},
+		})
+	}
+	return &abci.TxResult{
+		Height: height,
+		Index:  index,
+		Tx:     []byte(tx),
+		Result: abci.ExecTxResult{Code: abci.CodeTypeOK, Events: events},
+	}
+}
+
+// txLevelTx builds the rejected schema: a single tx-level event listing every
+// address and every role as separate attributes.
+func txLevelTx(height int64, index uint32, tx string, addresses, roles []string) *abci.TxResult {
+	attrs := make([]abci.EventAttribute, 0, len(addresses)+len(roles))
+	for _, address := range addresses {
+		attrs = append(attrs, abci.EventAttribute{Key: "address", Value: address, Index: true})
+	}
+	for _, role := range roles {
+		attrs = append(attrs, abci.EventAttribute{Key: "role", Value: role, Index: true})
+	}
+	return &abci.TxResult{
+		Height: height,
+		Index:  index,
+		Tx:     []byte(tx),
+		Result: abci.ExecTxResult{
+			Code:   abci.CodeTypeOK,
+			Events: []abci.Event{{Type: "shinzo", Attributes: attrs}},
+		},
+	}
+}
+
+func search(t *testing.T, idx *kv.TxIndex, q string) []string {
+	t.Helper()
+	parsed, err := query.New(q)
+	require.NoError(t, err)
+	results, err := idx.Search(context.Background(), parsed)
+	require.NoError(t, err)
+
+	txs := make([]string, 0, len(results))
+	for _, result := range results {
+		txs = append(txs, string(result.Tx))
+	}
+	return txs
+}
+
+func TestParticipantIndex(t *testing.T) {
+	idx := kv.NewTxIndex(dbm.NewMemDB())
+	require.NoError(t, idx.Index(participantTx(1, 0, "tx1", p("alice", "sender"), p("bob", "recipient"))))
+	require.NoError(t, idx.Index(participantTx(2, 0, "tx2", p("carol", "sender"), p("alice", "recipient"))))
+	require.NoError(t, idx.Index(participantTx(3, 0, "tx3", p("alice", "sender"), p("alice", "recipient"))))
+	require.NoError(t, idx.Index(participantTx(4, 0, "tx4", p("dave", "sender"), p("erin", "recipient"))))
+
+	// Single equality OR-matches across roles, and the self-transfer (tx3) is
+	// returned once.
+	require.ElementsMatch(t, []string{"tx1", "tx2", "tx3"},
+		search(t, idx, "shinzo.address='alice'"))
+
+	// Role binds to the address within one event: alice as sender is tx1 and tx3,
+	// not tx2 (where alice was the recipient).
+	require.ElementsMatch(t, []string{"tx1", "tx3"},
+		search(t, idx, "shinzo.address='alice' AND shinzo.role='sender'"))
+	require.ElementsMatch(t, []string{"tx2", "tx3"},
+		search(t, idx, "shinzo.address='alice' AND shinzo.role='recipient'"))
+
+	// An address that never appears returns nothing.
+	require.Empty(t, search(t, idx, "shinzo.address='zoe'"))
+}
+
+// TestTxLevelSchemaFalsePositive demonstrates the failure mode of the rejected
+// schema and is the empirical reason the decorators emit one event per participant.
+func TestTxLevelSchemaFalsePositive(t *testing.T) {
+	idx := kv.NewTxIndex(dbm.NewMemDB())
+	// carol -> alice, so alice is the recipient. Emitted as one tx-level event.
+	require.NoError(t, idx.Index(txLevelTx(1, 0, "tx5",
+		[]string{"carol", "alice"},
+		[]string{"sender", "recipient"})))
+
+	// The role query wrongly matches: address='alice' and role='sender' both have
+	// a matching value in the same event, even though alice was not the sender.
+	require.ElementsMatch(t, []string{"tx5"},
+		search(t, idx, "shinzo.address='alice' AND shinzo.role='sender'"))
+
+	// The same logical tx under the per-participant schema is correctly excluded.
+	perParticipant := kv.NewTxIndex(dbm.NewMemDB())
+	require.NoError(t, perParticipant.Index(participantTx(1, 0, "tx5",
+		p("carol", "sender"), p("alice", "recipient"))))
+	require.Empty(t,
+		search(t, perParticipant, "shinzo.address='alice' AND shinzo.role='sender'"))
+}


### PR DESCRIPTION
## Summary
- Adds a `shinzo` participant event per tx so transactions can be queried by address (sender or recipient) in a single CometBFT `tx_search`, with native pagination.

## Changes
- Cosmos ante decorator emits one `shinzo.address` event per participant: senders from the tx signers, recipients from value-transfer message fields (bank, IBC transfer, authz/feegrant grant, distribution).
- EVM ante path emits the same for `MsgEthereumTx` from/to. Emitted in the ante path so failed-execution txs stay queryable.