### PR TITLE
fix: derive did:key from the compressed pubkey

### DIFF
--- a/x/common/crypto/derivation.go
+++ b/x/common/crypto/derivation.go
@@ -10,16 +10,17 @@ import (
 
 // DeriveDID derives a DID from a secp256k1 node identity public key.
 //
-// The key is normalized to its uncompressed (65-byte) SEC1 encoding before the
-// DID is formed, so the resulting did:key is canonical regardless of whether the
-// caller supplied a compressed or uncompressed pubkey.
+// The key is normalized to its compressed (33-byte) SEC1 encoding before the DID
+// is formed. The secp256k1 did:key multicodec (0xe7) is defined over the compressed
+// key, so this yields the canonical did:key regardless of whether the caller
+// supplied a compressed or uncompressed pubkey.
 func DeriveDID(nodeIdPubkey []byte) (string, error) {
 	pk, err := secp256k1.ParsePubKey(nodeIdPubkey)
 	if err != nil {
 		return "", fmt.Errorf("invalid node identity pubkey: %w", err)
 	}
 
-	didDoc, err := didkey.CreateDIDKey(sdkcrypto.SECP256k1, pk.SerializeUncompressed())
+	didDoc, err := didkey.CreateDIDKey(sdkcrypto.SECP256k1, pk.SerializeCompressed())
 	if err != nil {
 		return "", fmt.Errorf("error creating did")
 	}

--- a/x/common/crypto/derivation_test.go
+++ b/x/common/crypto/derivation_test.go
@@ -1,0 +1,46 @@
+package crypto
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+// TestDeriveDID_Compressed pins the derived did:key for a known key and checks that
+// the compressed and uncompressed encodings of that key derive the same value. The
+// secp256k1 did:key multicodec (0xe7) is defined over the compressed key, so both
+// must produce the compressed form (zQ3s...), not the uncompressed one (z7r8...).
+func TestDeriveDID_Compressed(t *testing.T) {
+	const (
+		compressedHex = "02c2ca8868cd31f0c0ca8ffd3a58baa945623b1f0d6245611f27a43d954541a04c"
+		wantDID       = "did:key:zQ3shaXAyH7cPt1SiemqWtwXTt47EUWvCucxXmg1asUPdNk6P"
+	)
+	compressed, err := hex.DecodeString(compressedHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pk, err := secp256k1.ParsePubKey(compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, in := range map[string][]byte{
+		"compressed":   compressed,
+		"uncompressed": pk.SerializeUncompressed(),
+	} {
+		got, err := DeriveDID(in)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if got != wantDID {
+			t.Fatalf("%s input:\n want %s\n got  %s", name, wantDID, got)
+		}
+	}
+}
+
+func TestDeriveDID_InvalidPubkey(t *testing.T) {
+	if _, err := DeriveDID([]byte{0x00, 0x01, 0x02}); err == nil {
+		t.Fatal("want an error for an invalid pubkey")
+	}
+}


### PR DESCRIPTION
pin the compressed did derivation as the canonical version.
Resolves https://github.com/shinzonetwork/shinzohub/issues/89